### PR TITLE
Github: upgrade coveralls to 2.7.0

### DIFF
--- a/.github/workflows/codeception.yml
+++ b/.github/workflows/codeception.yml
@@ -83,5 +83,5 @@ jobs:
           CI: true
           COVERALLS_REPO_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         run: |
-          wget https://github.com/php-coveralls/php-coveralls/releases/download/v2.5.1/php-coveralls.phar
+          wget https://github.com/php-coveralls/php-coveralls/releases/download/v2.7.0/php-coveralls.phar
           php php-coveralls.phar --verbose --config tests/.coveralls.yml

--- a/.github/workflows/nette-tester-coverage.yml
+++ b/.github/workflows/nette-tester-coverage.yml
@@ -46,5 +46,5 @@ jobs:
           CI: true
           COVERALLS_REPO_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         run: |
-          wget https://github.com/php-coveralls/php-coveralls/releases/download/v2.5.3/php-coveralls.phar
+          wget https://github.com/php-coveralls/php-coveralls/releases/download/v2.7.0/php-coveralls.phar
           php php-coveralls.phar --verbose --config tests/.coveralls.yml

--- a/.github/workflows/nette-tester-mysql.yml
+++ b/.github/workflows/nette-tester-mysql.yml
@@ -71,5 +71,5 @@ jobs:
           CI: true
           COVERALLS_REPO_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         run: |
-          wget https://github.com/php-coveralls/php-coveralls/releases/download/v2.5.1/php-coveralls.phar
+          wget https://github.com/php-coveralls/php-coveralls/releases/download/v2.7.0/php-coveralls.phar
           php php-coveralls.phar --verbose --config tests/.coveralls.yml

--- a/.github/workflows/nette-tester-redis.yml
+++ b/.github/workflows/nette-tester-redis.yml
@@ -63,5 +63,5 @@ jobs:
           CI: true
           COVERALLS_REPO_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         run: |
-          wget https://github.com/php-coveralls/php-coveralls/releases/download/v2.5.1/php-coveralls.phar
+          wget https://github.com/php-coveralls/php-coveralls/releases/download/v2.7.0/php-coveralls.phar
           php php-coveralls.phar --verbose --config tests/.coveralls.yml

--- a/.github/workflows/nette-tester.yml
+++ b/.github/workflows/nette-tester.yml
@@ -52,5 +52,5 @@ jobs:
           CI: true
           COVERALLS_REPO_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         run: |
-          wget https://github.com/php-coveralls/php-coveralls/releases/download/v2.5.1/php-coveralls.phar
+          wget https://github.com/php-coveralls/php-coveralls/releases/download/v2.7.0/php-coveralls.phar
           php php-coveralls.phar --verbose --config tests/.coveralls.yml

--- a/.github/workflows/phpunit-coverage.yml
+++ b/.github/workflows/phpunit-coverage.yml
@@ -50,5 +50,5 @@ jobs:
           CI: true
           COVERALLS_REPO_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         run: |
-          wget https://github.com/php-coveralls/php-coveralls/releases/download/v2.5.3/php-coveralls.phar
+          wget https://github.com/php-coveralls/php-coveralls/releases/download/v2.7.0/php-coveralls.phar
           php php-coveralls.phar --verbose --config tests/.coveralls.yml

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -56,5 +56,5 @@ jobs:
           CI: true
           COVERALLS_REPO_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         run: |
-          wget https://github.com/php-coveralls/php-coveralls/releases/download/v2.5.1/php-coveralls.phar
+          wget https://github.com/php-coveralls/php-coveralls/releases/download/v2.7.0/php-coveralls.phar
           php php-coveralls.phar --verbose --config tests/.coveralls.yml


### PR DESCRIPTION
- https://github.com/php-coveralls/php-coveralls/releases/tag/v2.5.2
- https://github.com/php-coveralls/php-coveralls/releases/tag/v2.5.3
- https://github.com/php-coveralls/php-coveralls/releases/tag/v2.6.0
  fixes PHP 8.1
- https://github.com/php-coveralls/php-coveralls/releases/tag/v2.7.0
  drop PHP 5.x

Hoping this fixes the coverage segfaults in https://github.com/contributte/forms-multiplier/pull/102#issuecomment-2009098911
