### PR TITLE
Add amqp extension to default PHP extensions in setup action

### DIFF
--- a/.github/actions/setup-php/action.yml
+++ b/.github/actions/setup-php/action.yml
@@ -10,7 +10,7 @@ inputs:
   extensions:
     required: false
     type: string
-    default: "json, mongodb"
+    default: "json, amqp, mongodb"
 
   tools:
     required: false


### PR DESCRIPTION
## Summary
Updated the default PHP extensions configuration in the setup-php GitHub Action to include the AMQP extension alongside the existing JSON and MongoDB extensions.

## Changes
- Added `amqp` to the default extensions list in `.github/actions/setup-php/action.yml`
- Default extensions now: `json, amqp, mongodb`

## Details
This change ensures that the AMQP (Advanced Message Queuing Protocol) extension is automatically installed when the setup-php action is used without explicitly specifying extensions, making it available for workflows that depend on message queue functionality.

https://claude.ai/code/session_016XiQ75RgG5nduT6bB7BE1k